### PR TITLE
feat: Add map/reduce functions

### DIFF
--- a/get.js
+++ b/get.js
@@ -1,0 +1,28 @@
+const curry2 = require('./internal/curry2')
+const split = require('./split')
+const reduce = require('./reduce')
+
+/**
+ * Grab path in collection.
+ * @param {(string|string[])} path
+ * @param {(Object|Array)} [collection]
+ *
+ * @example
+ *
+ * get('a.b.c')
+ * get(['a', 'b', 'c'])
+ */
+function get (path, collection) {
+  let p = path
+  if (typeof p === 'string') {
+    p = split('.', p)
+  }
+  if (!Array.isArray(p)) {
+    return undefined
+  }
+  return reduce((acc, key) => (
+    acc && acc[key]
+  ), collection, p)
+}
+
+module.exports = curry2(get)

--- a/get.test.js
+++ b/get.test.js
@@ -1,0 +1,48 @@
+/* global describe, expect, test */
+
+const get = require('./get')
+
+describe('curry', () => {
+  test('curry works as intended', () => {
+    expect(get('a')({ a: 'horse' })).toBe('horse')
+    expect(get('a')).toBeInstanceOf(Function)
+  })
+})
+
+describe('object lookup', () => {
+  test('can get values with string keys', () => {
+    expect(get('a', { a: 'horse' })).toBe('horse')
+    expect(get('a.b', { a: { b: 123 } })).toBe(123)
+  })
+  test('can get values with array keys', () => {
+    expect(get(['a'], { a: 'horse' })).toBe('horse')
+    expect(get(['a', 'b'], { a: { b: 123 } })).toBe(123)
+  })
+})
+
+describe('array lookup', () => {
+  test('can get values with string (number) keys', () => {
+    expect(get('0', ['horse', 'sheep'])).toBe('horse')
+  })
+})
+
+describe('combined object/array lookup', () => {
+  test('can get values with string (number) keys', () => {
+    expect(get('a.1', { a: ['horse', 'sheep'] })).toBe('sheep')
+  })
+})
+
+describe('lookup of non-existent paths', () => {
+  test('gets undefined from crazy path', () => {
+    const obj = { a: { b: { d: 'horse' } } }
+    expect(get('a.b.c', obj)).toBeUndefined()
+    expect(get(null, obj)).toBeUndefined()
+    expect(get(NaN, obj)).toBeUndefined()
+    expect(get('', obj)).toBeUndefined()
+    expect(get([''], obj)).toBeUndefined()
+    expect(get([NaN, NaN], obj)).toBeUndefined()
+    expect(get([undefined], obj)).toBeUndefined()
+    expect(get([null], obj)).toBeUndefined()
+    expect(get([], obj)).toEqual(obj)
+  })
+})

--- a/internal/iteratee.js
+++ b/internal/iteratee.js
@@ -1,0 +1,11 @@
+const get = require('../get')
+
+function iteratee (keyOrFunction) {
+  if (typeof keyOrFunction === 'function') {
+    return keyOrFunction
+  } else {
+    return get(keyOrFunction)
+  }
+}
+
+module.exports = iteratee

--- a/map.js
+++ b/map.js
@@ -1,0 +1,16 @@
+const curry2 = require('./internal/curry2')
+const iteratee = require('./internal/iteratee')
+
+function map (keyOrFunction, array) {
+  let idx = -1
+  const length = Array.isArray(array) ? array.length : 0
+  let result = new Array(length)
+
+  while (++idx < length) {
+    result[idx] = iteratee(keyOrFunction)(array[idx], idx, array)
+  }
+
+  return result
+}
+
+module.exports = curry2(map)

--- a/map.test.js
+++ b/map.test.js
@@ -1,0 +1,20 @@
+/* global describe, expect, test */
+
+const map = require('./map')
+
+describe('curry', () => {
+  test('curry works as intended', () => {
+    expect(map(v => v * 2)([1])).toEqual([2])
+    expect(map(v => v * 2, [1])).toEqual([2])
+    expect(map('a')([{ a: 'horse' }])).toEqual(['horse'])
+    expect(map('a')).toBeInstanceOf(Function)
+  })
+})
+
+describe('advanced iteratees', () => {
+  test('nested keys', () => {
+    const a0 = [{ a: { b: 123 } }, { a: { b: 'c' } }]
+    expect(map('a.b', a0)).toEqual([123, 'c'])
+    expect(map(['a', 'b'], a0)).toEqual([123, 'c'])
+  })
+})

--- a/mapValues.js
+++ b/mapValues.js
@@ -1,0 +1,14 @@
+const curry2 = require('./internal/curry2')
+const iteratee = require('./internal/iteratee')
+
+function mapValues (keyOrFunction, object) {
+  let result = {}
+
+  for (let key of Object.keys(object)) {
+    result[key] = iteratee(keyOrFunction)(object[key])
+  }
+
+  return result
+}
+
+module.exports = curry2(mapValues)

--- a/mapValues.test.js
+++ b/mapValues.test.js
@@ -1,0 +1,24 @@
+/* global describe, expect, test */
+
+const mapValues = require('./mapValues')
+
+describe('curry', () => {
+  const o0 = { a: 1, b: 2 }
+  test('curry works as intended', () => {
+    expect(mapValues(v => v * 2)(o0)).toEqual({ a: 2, b: 4 })
+    expect(mapValues(v => v * 2, o0)).toEqual({ a: 2, b: 4 })
+    expect(mapValues(v => v * 2)).toBeInstanceOf(Function)
+  })
+})
+
+describe('advanced iteratees', () => {
+  const o0 = { a: { age: 32, stats: { speed: 100 } }, b: { age: 59, stats: { speed: 2 } } }
+  test('keys', () => {
+    expect(mapValues('age', o0)).toEqual({ a: 32, b: 59 })
+    expect(mapValues(['age'], o0)).toEqual({ a: 32, b: 59 })
+  })
+  test('nested keys', () => {
+    expect(mapValues('stats.speed', o0)).toEqual({ a: 100, b: 2 })
+    expect(mapValues(['stats', 'speed'], o0)).toEqual({ a: 100, b: 2 })
+  })
+})

--- a/reduce.js
+++ b/reduce.js
@@ -1,0 +1,14 @@
+const curry3 = require('./internal/curry3')
+
+function reduce (iteratee, accumulator, array) {
+  let idx = -1
+  const length = Array.isArray(array) ? array.length : 0
+
+  while (++idx < length) {
+    accumulator = iteratee(accumulator, array[idx], idx, array)
+  }
+
+  return accumulator
+}
+
+module.exports = curry3(reduce)

--- a/split.js
+++ b/split.js
@@ -1,0 +1,12 @@
+const curry2 = require('./internal/curry2')
+
+/**
+ * Split string into array by delimeter.
+ * @param {string} delimeter
+ * @param {string} string
+ */
+function split (delimeter, string) {
+  return (string || '').split(delimeter)
+}
+
+module.exports = curry2(split)

--- a/split.test.js
+++ b/split.test.js
@@ -1,0 +1,23 @@
+/* global describe, expect, test */
+
+const split = require('./split')
+
+describe('split', () => {
+  const a = 'a|b|c'
+  const b = 'a--b-c'
+  test('curry works as intended', () => {
+    expect(split('|', a)).toEqual(['a', 'b', 'c'])
+    expect(split('|')(a)).toEqual(['a', 'b', 'c'])
+    expect(split('|')).toBeInstanceOf(Function)
+  })
+  test('multicharacter delimeter', () => {
+    expect(split('-', b)).toEqual(['a', '', 'b', 'c'])
+    expect(split('--', b)).toEqual(['a', 'b-c'])
+  })
+  test('negative cases', () => {
+    expect(split(undefined, a)).toEqual([a])
+    expect(split(0, a)).toEqual([a])
+    expect(split(null, a)).toEqual([a])
+    expect(split(NaN, a)).toEqual([a])
+  })
+})


### PR DESCRIPTION
Depends on `get` (path-like function) and `split` (known from String.split)