### PR TITLE
chore: Add travis-ci for some NodeJS versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+---
+language: node_js
+cache:
+  directories:
+  - node_modules
+matrix:
+  include:
+    - node_js: "6"
+    - node_js: "7"
+    - node_js: "8"
+    - node_js: "9"
+    - node_js: "10"
+    - node_js: "11"
+sudo: false
+install: npm install


### PR DESCRIPTION
Can't go lower since jest isn't supported under Node 6.